### PR TITLE
Add javax.activation dependencies to pom.xml

### DIFF
--- a/APIJSONORM/pom.xml
+++ b/APIJSONORM/pom.xml
@@ -24,6 +24,11 @@
 			<artifactId>fastjson</artifactId>
 			<version>1.2.74</version>
 		</dependency>
+		<dependency>
+			<groupId>javax.activation</groupId>
+			<artifactId>activation</artifactId>
+			<version>1.1.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
Add javax.activation dependencies to pom.xml so it could be built with newer version of JDK starting from 11 which removed the deprecated Java EE and CORBA Modules according to JEP 320

Signed-off-by: Xiaoguang Sun <sunxiaoguang@zhihu.com>