### PR TITLE
fix:解决数据源为Oracle时，@explain 报错问题；使用自增主键，代码中获取不到插入id问题

### DIFF
--- a/APIJSONORM/src/main/java/apijson/orm/AbstractSQLConfig.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractSQLConfig.java
@@ -3979,7 +3979,7 @@ public abstract class AbstractSQLConfig implements SQLConfig {
 			}
 			return "DELETE FROM " + tablePath + config.getWhereString(true) + (config.isMySQL() ? config.getLimitString() : "");  // PostgreSQL 不允许 LIMIT
 		default:
-			String explain = (config.isExplain() ? (config.isSQLServer() || config.isOracle() ? "SET STATISTICS PROFILE ON  " : "EXPLAIN ") : "");
+			String explain = config.isExplain() ? (config.isSQLServer() ? "SET STATISTICS PROFILE ON  " : (config.isOracle() ? "EXPLAIN PLAN FOR " : "EXPLAIN ")) : "";
 			if (config.isTest() && RequestMethod.isGetMethod(config.getMethod(), true)) {  // FIXME 为啥是 code 而不是 count ？
 				String q = config.getQuote();  // 生成 SELECT  (  (24 >=0 AND 24 <3)  )  AS `code` LIMIT 1 OFFSET 0
 				return explain + "SELECT " + config.getWhereString(false) + " AS " + q + JSONResponse.KEY_COUNT + q + config.getLimitString();


### PR DESCRIPTION
1. 解决数据源为Oracle时，使用性能分析关键字 @explain，查询报 "ORA-00922: 选项缺失或无效"问题
issue #432
closes #432

2. 解决数据源为Oracle时，使用自增主键，获取不到插入的主键问题
issue #338