### PR TITLE
定义 UnsupportedDataTypeException 类代替 javax.activation.Unsupported…

### DIFF
--- a/APIJSONORM/pom.xml
+++ b/APIJSONORM/pom.xml
@@ -23,11 +23,6 @@
 			<artifactId>fastjson</artifactId>
 			<version>1.2.83</version>
 		</dependency>
-		<dependency>
-			<groupId>javax.activation</groupId>
-			<artifactId>activation</artifactId>
-			<version>1.1.1</version>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/APIJSONORM/src/main/java/apijson/orm/AbstractFunctionParser.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractFunctionParser.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.activation.UnsupportedDataTypeException;
 import javax.script.Invocable;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
@@ -27,6 +26,7 @@ import apijson.Log;
 import apijson.NotNull;
 import apijson.RequestMethod;
 import apijson.StringUtil;
+import apijson.orm.exception.UnsupportedDataTypeException;
 
 /**可远程调用的函数类
  * @author Lemon

--- a/APIJSONORM/src/main/java/apijson/orm/AbstractObjectParser.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractObjectParser.java
@@ -14,11 +14,11 @@ import apijson.orm.AbstractFunctionParser.FunctionBean;
 import apijson.orm.exception.ConflictException;
 import apijson.orm.exception.CommonException;
 import apijson.orm.exception.NotExistException;
+import apijson.orm.exception.UnsupportedDataTypeException;
 import com.alibaba.fastjson.JSON;
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
 
-import javax.activation.UnsupportedDataTypeException;
 import java.rmi.ServerException;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/APIJSONORM/src/main/java/apijson/orm/AbstractParser.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractParser.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import javax.activation.UnsupportedDataTypeException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import javax.management.Query;
@@ -38,6 +37,7 @@ import apijson.NotNull;
 import apijson.RequestMethod;
 import apijson.StringUtil;
 import apijson.orm.exception.CommonException;
+import apijson.orm.exception.UnsupportedDataTypeException;
 
 import static apijson.JSONObject.KEY_EXPLAIN;
 import static apijson.RequestMethod.CRUD;

--- a/APIJSONORM/src/main/java/apijson/orm/AbstractSQLConfig.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractSQLConfig.java
@@ -20,8 +20,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import javax.activation.UnsupportedDataTypeException;
-
 import apijson.JSON;
 import apijson.JSONResponse;
 import apijson.Log;
@@ -31,6 +29,7 @@ import apijson.SQL;
 import apijson.StringUtil;
 import apijson.orm.Join.On;
 import apijson.orm.exception.NotExistException;
+import apijson.orm.exception.UnsupportedDataTypeException;
 import apijson.orm.model.Access;
 import apijson.orm.model.AllColumn;
 import apijson.orm.model.AllColumnComment;

--- a/APIJSONORM/src/main/java/apijson/orm/AbstractVerifier.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractVerifier.java
@@ -41,8 +41,6 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.regex.Pattern;
 
-import javax.activation.UnsupportedDataTypeException;
-
 import com.alibaba.fastjson.JSONArray;
 import com.alibaba.fastjson.JSONObject;
 
@@ -56,6 +54,7 @@ import apijson.StringUtil;
 import apijson.orm.AbstractSQLConfig.IdCallback;
 import apijson.orm.exception.ConflictException;
 import apijson.orm.exception.NotLoggedInException;
+import apijson.orm.exception.UnsupportedDataTypeException;
 import apijson.orm.model.Access;
 import apijson.orm.model.Column;
 import apijson.orm.model.Document;

--- a/APIJSONORM/src/main/java/apijson/orm/exception/CommonException.java
+++ b/APIJSONORM/src/main/java/apijson/orm/exception/CommonException.java
@@ -9,8 +9,6 @@ import java.io.UnsupportedEncodingException;
 import java.sql.SQLException;
 import java.util.concurrent.TimeoutException;
 
-import javax.activation.UnsupportedDataTypeException;
-
 import apijson.JSONResponse;
 import apijson.Log;
 import apijson.StringUtil;

--- a/APIJSONORM/src/main/java/apijson/orm/exception/UnsupportedDataTypeException.java
+++ b/APIJSONORM/src/main/java/apijson/orm/exception/UnsupportedDataTypeException.java
@@ -1,0 +1,26 @@
+/*Copyright (C) 2020 THL A29 Limited, a Tencent company.  All rights reserved.
+
+This source code is licensed under the Apache License Version 2.0.*/
+
+
+package apijson.orm.exception;
+
+import java.io.IOException;
+
+/**
+ * 给定的数据类型不被支持
+ *
+ * @author cnscoo
+ */
+
+public class UnsupportedDataTypeException extends IOException {
+    private static final long serialVersionUID = 1L;
+
+    public UnsupportedDataTypeException() {
+        super();
+    }
+
+    public UnsupportedDataTypeException(String s) {
+        super(s);
+    }
+}


### PR DESCRIPTION
refactor: 定义 UnsupportedDataTypeException 类代替 javax.activation.UnsupportedDataTypeException

减少不需要的依赖

- 定义 UnsupportedDataTypeException 类代替 javax.activation.UnsupportedDataTypeException
- 移除javax.activation依赖

issue #488
closes #488