### PR TITLE
GETS/HEADS/PUT/DELETE 不允许前端传 @combine

### DIFF
--- a/APIJSONORM/src/main/java/apijson/orm/AbstractParser.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractParser.java
@@ -39,6 +39,7 @@ import apijson.StringUtil;
 import apijson.orm.exception.CommonException;
 import apijson.orm.exception.UnsupportedDataTypeException;
 
+import static apijson.JSONObject.KEY_COMBINE;
 import static apijson.JSONObject.KEY_EXPLAIN;
 import static apijson.RequestMethod.CRUD;
 import static apijson.RequestMethod.GET;
@@ -2192,6 +2193,10 @@ public abstract class AbstractParser<T extends Object> implements Parser<T>, Par
 					RequestMethod  _method = null;
 					if (request.get(key) instanceof JSONObject) {
 						_method = RequestMethod.valueOf(request.getJSONObject(key).getString(apijson.JSONObject.KEY_METHOD).toUpperCase());
+						String combine = request.getJSONObject(key).getString(KEY_COMBINE);
+						if (combine != null && (_method == RequestMethod.DELETE || _method == RequestMethod.GETS || _method == RequestMethod.HEADS)) {
+							throw new IllegalArgumentException(key + ":{} 里的 @combine:value 不合法！DELETE,GETS,HEADS 请求不允许传 @combine:value !");
+						}
 					} else {
 						if (keyObjectAttributesMap.get(key) == null) {
 							if (method == RequestMethod.CRUD) {

--- a/APIJSONORM/src/main/java/apijson/orm/AbstractParser.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractParser.java
@@ -2194,8 +2194,8 @@ public abstract class AbstractParser<T extends Object> implements Parser<T>, Par
 					if (request.get(key) instanceof JSONObject) {
 						_method = RequestMethod.valueOf(request.getJSONObject(key).getString(apijson.JSONObject.KEY_METHOD).toUpperCase());
 						String combine = request.getJSONObject(key).getString(KEY_COMBINE);
-						if (combine != null && (_method == RequestMethod.DELETE || _method == RequestMethod.GETS || _method == RequestMethod.HEADS)) {
-							throw new IllegalArgumentException(key + ":{} 里的 @combine:value 不合法！DELETE,GETS,HEADS 请求不允许传 @combine:value !");
+						if (combine != null && RequestMethod.isPublicMethod(_method) == false) {
+							throw new IllegalArgumentException(key + ":{} 里的 @combine:value 不合法！开放请求 GET、HEAD 才允许传 @combine:value !");
 						}
 					} else {
 						if (keyObjectAttributesMap.get(key) == null) {


### PR DESCRIPTION
https://github.com/Tencent/APIJSON/pull/493
GETS/HEADS/PUT/DELETE 不允许前端传 @combine，目前在这里去掉了校验，需要在 AbstractVerifier 补上，这样就只能通过后端配置 @combine 了，既保证了功能，又保证了安全