### PR TITLE
支持了请求校验字符串长度的规则

### DIFF
--- a/APIJSONORM/src/main/java/apijson/orm/Operation.java
+++ b/APIJSONORM/src/main/java/apijson/orm/Operation.java
@@ -54,6 +54,7 @@ public enum Operation {
 	 * {
 	 *   "phone~": "PHONE",  //phone 必须满足 PHONE 的格式，配置见 {@link AbstractVerifier#COMPILE_MAP}
 	 *   "status{}": [1,2,3],  //status 必须在给出的范围内
+	 *   "content{L}": ">0,<=255",  //content的长度 必须在给出的范围内
 	 *   "balance&{}":">0,<=10000"  //必须满足 balance>0 & balance<=10000
 	 * }
 	 */


### PR DESCRIPTION
{"Moment":{"MUST": "userId","VERIFY":{"userId&{}":">0,<=10000","content{L}":">1,<=10"}}}

规则依然是定义在VERIFY里，key通过content{L} 大括号中间增加了一个L标识为校验length，value依然是通过> >= < <= 配置
"content{L}":">1,<=10"代表 content的长度大于1并且小于等于10