### PR TITLE
Added support for hyphen(-) under email regex

### DIFF
--- a/APIJSONORM/src/main/java/apijson/StringUtil.java
+++ b/APIJSONORM/src/main/java/apijson/StringUtil.java
@@ -357,7 +357,7 @@ public class StringUtil {
 		PATTERN_NAME = Pattern.compile("^[0-9a-zA-Z_.:]+$");//已用55个中英字符测试通过
 		//newest phone regex expression reference https://github.com/VincentSit/ChinaMobilePhoneNumberRegex
 		PATTERN_PHONE = Pattern.compile("^1(?:3\\d{3}|5[^4\\D]\\d{2}|8\\d{3}|7(?:[0-35-9]\\d{2}|4(?:0\\d|1[0-2]|9\\d))|9[0-35-9]\\d{2}|6[2567]\\d{2}|4(?:(?:10|4[01])\\d{3}|[68]\\d{4}|[579]\\d{2}))\\d{6}$");
-		PATTERN_EMAIL = Pattern.compile("^([a-zA-Z0-9_\\-\\.]+)@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.)|(([a-zA-Z0-9\\-]+\\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\\]?)$");
+		PATTERN_EMAIL = Pattern.compile("^([a-zA-Z0-9_\-\\.]+)@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.)|(([a-zA-Z0-9\\-]+\\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\\]?)$");
 		PATTERN_ID_CARD = Pattern.compile("(^[1-9]\\d{5}(18|19|([23]\\d))\\d{2}((0[1-9])|(10|11|12))(([0-2][1-9])|10|20|30|31)\\d{3}[0-9Xx]$)|(^[1-9]\\d{5}\\d{2}((0[1-9])|(10|11|12))(([0-2][1-9])|10|20|30|31)\\d{2}$)");
 		PATTERN_PASSWORD = Pattern.compile("^[0-9a-zA-Z]+$");
 		PATTERN_BRANCH_URL = Pattern.compile("^[0-9a-zA-Z-_/]+$");


### PR DESCRIPTION
Current version of email regex don't have support for hyphen(-). I have updated the existing regex which has duplicate slash symbol twice in first square bracket, which is redundant.

Executed some test cases here: https://regex101.com/r/qiNqNc/1