### PR TITLE
Update AbstractParser.java

### DIFF
--- a/APIJSONORM/src/main/java/apijson/orm/AbstractParser.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractParser.java
@@ -2229,6 +2229,13 @@ public abstract class AbstractParser<T extends Object> implements Parser<T>, Par
 						continue;
 					}
 
+					if(tag != null && !tag.contains("\\:")) {
+						JSONObject object = getRequestStructure(_method, tag, version);
+						JSONObject ret = objectVerify(_method, tag, version, name, request, maxUpdateCount, creator, object);
+						jsonObject.putAll(ret);
+						break;
+					}
+
 					String _tag = buildTag(request, key, method, tag);
 					JSONObject requestItem = new JSONObject();
 					// key 处理别名

--- a/APIJSONORM/src/main/java/apijson/orm/AbstractParser.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractParser.java
@@ -2229,7 +2229,7 @@ public abstract class AbstractParser<T extends Object> implements Parser<T>, Par
 						continue;
 					}
 
-					if(tag != null && !tag.contains("\\:")) {
+					if(tag != null && !tag.contains(":")) {
 						JSONObject object = getRequestStructure(_method, tag, version);
 						JSONObject ret = objectVerify(_method, tag, version, name, request, maxUpdateCount, creator, object);
 						jsonObject.putAll(ret);


### PR DESCRIPTION
修正BUG #512
追加适配老版本多表联查问题  外层一个tag只需要校验一遍即可,这里没有直接修正requestItem.put(_key, obj);为requestItem.putAll(Request对象);因为这个是for循环校验，而老版本只需要校验一次整体JSON即可。
![1111](https://user-images.githubusercontent.com/28621460/231675508-75954f2d-ae2f-4bae-9f68-31aaedf65fa5.png)
![2222](https://user-images.githubusercontent.com/28621460/231675538-4c8b0929-a6d1-4737-9e16-c9d5efd4b742.png)
![3333](https://user-images.githubusercontent.com/28621460/231675550-422df68b-cf02-4cca-a5da-87769990e6d5.png)
![4444](https://user-images.githubusercontent.com/28621460/231675557-05f85a49-7a14-4c34-a43b-e32a1ab901b0.png)
做了几个测试。