### PR TITLE
Update AbstractSQLConfig.java

### DIFF
--- a/APIJSONORM/src/main/java/apijson/orm/AbstractSQLConfig.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractSQLConfig.java
@@ -883,7 +883,7 @@ public abstract class AbstractSQLConfig<T extends Object> implements SQLConfig<T
 
 	@Override
 	public boolean limitSQLCount() {
-		return Log.DEBUG == false || AbstractVerifier.SYSTEM_ACCESS_MAP.containsKey(getTable()) == false;
+		return AbstractVerifier.SYSTEM_ACCESS_MAP.containsKey(getTable()) == false;
 	}
 	@Override
 	public boolean allowPartialUpdateFailed() {


### PR DESCRIPTION
refactor: 去掉Access, Request初始化限制

这里 Log.DEBUG == false 应该去掉，毕竟上线前要 Log.DEBUG = true 减少日志打印等，会导致上线后初始化加载 Access, Request 表记录仍然限制最大 Parser.getMaxQueryCount（默认 100）。

issue #640
closes #640