### PR TITLE
commit update join支持@cast字段类型转换

### DIFF
--- a/APIJSONORM/src/main/java/apijson/orm/AbstractSQLConfig.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractSQLConfig.java
@@ -4847,8 +4847,20 @@ public abstract class AbstractSQLConfig<T extends Object> implements SQLConfig<T
 
 				String rt = on.getRelateType();
 				if (StringUtil.isEmpty(rt, false)) {
-					sql += (first ? ON : AND) + quote + jt + quote + "." + quote + on.getKey() + quote + (isNot ? " != " : " = ")
-							+ quote + getSQLTableWithAlias(on.getTargetTable(), on.getTargetAlias()) + quote + "." + quote + on.getTargetKey() + quote;
+					//解决join不支持@cast问题
+					Map castMap = j.getJoinConfig().getCast();
+					if (castMap.isEmpty()) {
+						sql += (first ? ON : AND) + quote + jt + quote + "." + quote + on.getKey() + quote + (isNot ? " != " : " = ")
+								+ quote + on.getTargetTable() + quote + "." + quote + on.getTargetKey() + quote;
+					} else {
+						String leftTableRelationSql = quote + jt + quote + "." + quote + on.getKey() + quote;
+						Object castValueType = castMap.get(on.getOriginKey());
+						if (castValueType != null) {
+							leftTableRelationSql = "CAST(" + leftTableRelationSql + " AS " + castValueType + ")";
+						}
+						sql += (first ? ON : AND) + leftTableRelationSql + (isNot ? " != " : " = ")
+								+ quote + on.getTargetTable() + quote + "." + quote + on.getTargetKey() + quote;
+					}
 				}
 				else {
 					onJoinComplexRelation(sql, quote, j, jt, onList, on);

--- a/APIJSONORM/src/main/java/apijson/orm/AbstractSQLConfig.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractSQLConfig.java
@@ -4847,9 +4847,10 @@ public abstract class AbstractSQLConfig<T extends Object> implements SQLConfig<T
 
 				String rt = on.getRelateType();
 				if (StringUtil.isEmpty(rt, false)) {
-					//解决join不支持@cast问题
-					Map castMap = j.getJoinConfig().getCast();
-					if (castMap.isEmpty()) {
+					// 解决 JOIN ON 不支持 @cast 问题
+					SQLConfig jc = j.getJoinConfig();
+					Map<String, String> castMap = jc == null ? null : jc.getCast();
+					if (castMap == null || castMap.isEmpty()) {
 						sql += (first ? ON : AND) + quote + jt + quote + "." + quote + on.getKey() + quote + (isNot ? " != " : " = ")
 								+ quote + on.getTargetTable() + quote + "." + quote + on.getTargetKey() + quote;
 					} else {


### PR DESCRIPTION
在实际业务场景中存在关联字段类型不一致的情况，目前的代码在left join关联时发现无法兼容字段类型不一致的情况，需要在sql中拼接cast函数进行转换

如：pg数据库A表id为int、B表id_str为varchar、C表id为int

打印出来的sql为：
`SELECT "A".*, "B".*, "C".* FROM "public"."A" AS "A"  
   LEFT JOIN ( SELECT * FROM "public"."B" ) AS "B" ON "B"."id_str" = "A"."id"  
   LEFT JOIN ( SELECT * FROM "public"."C" ) AS "C" ON "C"."id" = "B"."id_str"  
 LIMIT 20000`

导致出现类型不匹配的错误
<img width="683" alt="image" src="https://github.com/user-attachments/assets/33aaf19b-ae04-488d-bf83-c40e64a6672c" />

修改代码兼容cast函数后

打印出来的sql为：
`SELECT "A".*, "B".*, "C".* FROM "public"."A" AS "A"  
   LEFT JOIN ( SELECT * FROM "public"."B" ) AS "B" ON CAST("B"."id_str" AS integer) = "A"."id"  
   LEFT JOIN ( SELECT * FROM "public"."C" ) AS "C" ON CAST("C"."id" AS varchar) = "B"."id_str"  
 LIMIT 20000`

数据响应成功
<img width="546" alt="image" src="https://github.com/user-attachments/assets/b2df6814-517a-4a18-a17f-e3110647c23c" />

