### PR TITLE
fix: 在Head Method，MySql数据性能最优解，其他数据库如PG数据库需要  LEFT JOIN 其他键时直接(select…

### DIFF
--- a/APIJSONORM/src/main/java/apijson/orm/AbstractSQLConfig.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractSQLConfig.java
@@ -6322,12 +6322,15 @@ public abstract class AbstractSQLConfig<T, M extends Map<String, Object>, L exte
 			if (RequestMethod.isHeadMethod(method, true)) {
 				List<On> onList = join.getOnList();
 				List<String> column = onList == null ? null : new ArrayList<>(onList.size());
-				if (column != null) {
-					for (On on : onList) {
-						//解决 pg  如果只查询关联键，会报找不到column的错误
-						///* SELECT  count(*)  AS count  FROM sys.Moment AS Moment
-						//			   LEFT JOIN ( SELECT *  FROM sys.Comment ) AS Comment ON Comment.momentId = Moment.id LIMIT 1 OFFSET 0 */
-						//column.add(on.getKey());
+				//解决 pg  如果只查询关联键，会报找不到column的错误
+				///* SELECT  count(*)  AS count  FROM sys.Moment AS Moment
+				//			   LEFT JOIN ( SELECT *  FROM sys.Comment ) AS Comment ON Comment.momentId = Moment.id LIMIT 1 OFFSET 0 */
+				if (joinConfig.isMySQL()) {
+					if (column != null) {
+						for (On on : onList) {
+							column.add(on.getKey());
+						}
+
 					}
 				}
 

--- a/APIJSONORM/src/main/java/apijson/orm/AbstractSQLConfig.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractSQLConfig.java
@@ -6325,12 +6325,9 @@ public abstract class AbstractSQLConfig<T, M extends Map<String, Object>, L exte
 				//解决 pg  如果只查询关联键，会报找不到column的错误
 				///* SELECT  count(*)  AS count  FROM sys.Moment AS Moment
 				//			   LEFT JOIN ( SELECT *  FROM sys.Comment ) AS Comment ON Comment.momentId = Moment.id LIMIT 1 OFFSET 0 */
-				if (joinConfig.isMySQL()) {
-					if (column != null) {
-						for (On on : onList) {
-							column.add(on.getKey());
-						}
-
+				if (column != null && joinConfig.isMSQL()) { // 暂时这样兼容 PostgreSQL 等不支持 SELECT 中不包含对应 key 的隐式 ON 关联字段的数据库
+					for (On on : onList) {
+						column.add(on.getKey()); // TODO PostgreSQL 等需要找到具体的 targetTable 对应 targetKey 来加到 SELECT，比直接 SELECT * 性能更好
 					}
 				}
 


### PR DESCRIPTION
… * from A.a) 避免找不到column的错误