### PR TITLE
Join.java 中 SQLConfig outerConfig 重命名成 onConfig,然后用原来的 outerConfig 增加最外层的where 查询条件

### DIFF
--- a/APIJSONORM/src/main/java/apijson/orm/AbstractParser.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractParser.java
@@ -1563,39 +1563,39 @@ public abstract class AbstractParser<T, M extends Map<String, Object>, L extends
 			throw new UnsupportedDataTypeException(TAG + ".onJoinParse  join 只能是 String 或 Map<String, Object> 类型！");
 		}
 
-        List<Entry<String, Object>> slashKeys = new ArrayList<>();
-        List<Entry<String, Object>> nonSlashKeys = new ArrayList<>();
-        Set<Entry<String, Object>> entries = joinMap == null ? null : joinMap.entrySet();
+		List<Entry<String, Object>> slashKeys = new ArrayList<>();
+		List<Entry<String, Object>> nonSlashKeys = new ArrayList<>();
+		Set<Entry<String, Object>> entries = joinMap == null ? null : joinMap.entrySet();
 
-        if (entries == null || entries.isEmpty()) {
-            Log.e(TAG, "onJoinParse  set == null || set.isEmpty() >> return null;");
-            return null;
-        }
-        for (Entry<String, Object> e : entries) {
-            String path = e.getKey();
-            if (path != null && path.indexOf("/") > 0) {
-                slashKeys.add(e);  // 以 / 开头的 key，例如 </Table/key@
-            } else {
-                nonSlashKeys.add(e);  // 普通 key，例如 Table: {}
-            }
-        }
+		if (entries == null || entries.isEmpty()) {
+			Log.e(TAG, "onJoinParse  set == null || set.isEmpty() >> return null;");
+			return null;
+		}
+		for (Entry<String, Object> e : entries) {
+			String path = e.getKey();
+			if (path != null && path.indexOf("/") > 0) {
+				slashKeys.add(e);  // 以 / 开头的 key，例如 </Table/key@
+			} else {
+				nonSlashKeys.add(e);  // 普通 key，例如 Table: {}
+			}
+		}
 
-        Map<String, Object> whereJoinMap = new LinkedHashMap<>();
+		Map<String, Object> whereJoinMap = new LinkedHashMap<>();
 
-        for (Entry<String, Object> e : nonSlashKeys) {
-            String tableKey = e.getKey(); // 如 "Location_info"
-            Object tableObj = e.getValue(); // value 是 Map
+		for (Entry<String, Object> e : nonSlashKeys) {
+			String tableKey = e.getKey(); // 如 "Location_info"
+			Object tableObj = e.getValue(); // value 是 Map
 
-            if (request.containsKey(tableKey)) {
-                whereJoinMap.put(tableKey, tableObj);
-            } else {
-                Log.w(TAG, "跳过 join 中 key = " + tableKey + "，因为它不在 request 中");
-            }
-        }
+			if (request.containsKey(tableKey)) {
+				whereJoinMap.put(tableKey, tableObj);
+			} else {
+				Log.w(TAG, "跳过 join 中 key = " + tableKey + "，因为它不在 request 中");
+			}
+		}
 
 
-        Set<Entry<String, Object>> set = joinMap == null ? null : new LinkedHashSet<>(slashKeys);
-        ;
+		Set<Entry<String, Object>> set = joinMap == null ? null : new LinkedHashSet<>(slashKeys);
+
 		if (set == null || set.isEmpty()) {
 			Log.e(TAG, "onJoinParse  set == null || set.isEmpty() >> return null;");
 			return null;

--- a/APIJSONORM/src/main/java/apijson/orm/AbstractParser.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractParser.java
@@ -1563,7 +1563,39 @@ public abstract class AbstractParser<T, M extends Map<String, Object>, L extends
 			throw new UnsupportedDataTypeException(TAG + ".onJoinParse  join 只能是 String 或 Map<String, Object> 类型！");
 		}
 
-		Set<Entry<String, Object>> set = joinMap == null ? null : joinMap.entrySet();
+        List<Entry<String, Object>> slashKeys = new ArrayList<>();
+        List<Entry<String, Object>> nonSlashKeys = new ArrayList<>();
+        Set<Entry<String, Object>> entries = joinMap == null ? null : joinMap.entrySet();
+
+        if (entries == null || entries.isEmpty()) {
+            Log.e(TAG, "onJoinParse  set == null || set.isEmpty() >> return null;");
+            return null;
+        }
+        for (Entry<String, Object> e : entries) {
+            String path = e.getKey();
+            if (path != null && path.indexOf("/") > 0) {
+                slashKeys.add(e);  // 以 / 开头的 key，例如 </Table/key@
+            } else {
+                nonSlashKeys.add(e);  // 普通 key，例如 Table: {}
+            }
+        }
+
+        Map<String, Object> whereJoinMap = new LinkedHashMap<>();
+
+        for (Entry<String, Object> e : nonSlashKeys) {
+            String tableKey = e.getKey(); // 如 "Location_info"
+            Object tableObj = e.getValue(); // value 是 Map
+
+            if (request.containsKey(tableKey)) {
+                whereJoinMap.put(tableKey, tableObj);
+            } else {
+                Log.w(TAG, "跳过 join 中 key = " + tableKey + "，因为它不在 request 中");
+            }
+        }
+
+
+        Set<Entry<String, Object>> set = joinMap == null ? null : new LinkedHashSet<>(slashKeys);
+        ;
 		if (set == null || set.isEmpty()) {
 			Log.e(TAG, "onJoinParse  set == null || set.isEmpty() >> return null;");
 			return null;
@@ -1759,8 +1791,14 @@ public abstract class AbstractParser<T, M extends Map<String, Object>, L extends
 			j.setAlias(alias);
 
 			M outerObj = (M) JSON.createJSONObject((Map<String, Object>) outer);
-			j.setOuter(outerObj);
+            j.setOn(outerObj);
 			j.setRequest(requestObj);
+
+            if (whereJoinMap.containsKey(table)) {
+                Object rawOuter = whereJoinMap.get(table);
+                M outerObj1 = (M) JSON.createJSONObject((Map<String, Object>) rawOuter);
+                j.setOuter(outerObj1);
+            }
 
 			if (arrKey != null) {
 				Integer count = getInteger(parentPathObj, apijson.JSONRequest.KEY_COUNT);

--- a/APIJSONORM/src/main/java/apijson/orm/AbstractSQLConfig.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractSQLConfig.java
@@ -5,42 +5,21 @@ This source code is licensed under the Apache License Version 2.0.*/
 
 package apijson.orm;
 
-import java.util.*;
-import java.util.Map.Entry;
-import java.util.regex.Pattern;
-
 import apijson.*;
 import apijson.orm.Join.On;
 import apijson.orm.exception.NotExistException;
 import apijson.orm.exception.UnsupportedDataTypeException;
-import apijson.orm.model.Access;
-import apijson.orm.model.AllColumn;
-import apijson.orm.model.AllColumnComment;
-import apijson.orm.model.AllTable;
-import apijson.orm.model.AllTableComment;
-import apijson.orm.model.Column;
-import apijson.orm.model.Document;
-import apijson.orm.model.ExtendedProperty;
-import apijson.orm.model.Function;
-import apijson.orm.model.PgAttribute;
-import apijson.orm.model.PgClass;
-import apijson.orm.model.Request;
-import apijson.orm.model.SysColumn;
-import apijson.orm.model.SysTable;
-import apijson.orm.model.Table;
-import apijson.orm.model.TestRecord;
+import apijson.orm.model.*;
+
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.regex.Pattern;
 
 import static apijson.JSON.getBoolean;
 import static apijson.JSON.getString;
 import static apijson.JSONMap.*;
-import static apijson.RequestMethod.DELETE;
-import static apijson.RequestMethod.GET;
-import static apijson.RequestMethod.POST;
-import static apijson.RequestMethod.PUT;
-import static apijson.SQL.AND;
-import static apijson.SQL.NOT;
-import static apijson.SQL.ON;
-import static apijson.SQL.OR;
+import static apijson.RequestMethod.*;
+import static apijson.SQL.*;
 
 /**config sql for JSON Request
  * @author Lemon
@@ -1574,7 +1553,7 @@ public abstract class AbstractSQLConfig<T, M extends Map<String, Object>, L exte
 					continue;
 				}
 
-				SQLConfig<T, M, L> ocfg = join.getOuterConfig();
+				SQLConfig<T, M, L> ocfg = join.getOnConfig();
 				SQLConfig<T, M, L> cfg = (ocfg != null && ocfg.getGroup() != null) || join.isLeftOrRightJoin() ? ocfg : join.getJoinConfig();
 
 				if (cfg != null) {
@@ -1589,6 +1568,23 @@ public abstract class AbstractSQLConfig<T, M extends Map<String, Object>, L exte
 						first = false;
 					}
 				}
+
+				////先处理左/右关联，内关联忽略
+				//SQLConfig<T, M, L> outerConfig = join.getOuterConfig();
+				//SQLConfig<T, M, L> outerConfig2 = (outerConfig != null && outerConfig.getGroup() != null) || join.isLeftOrRightJoin() ? outerConfig : null;
+				//
+				//if (outerConfig2 != null) {
+				//	outerConfig2.setMain(false).setKeyPrefix(true);
+				//	//if (StringUtil.isEmpty(cfg.getAlias(), true)) {
+				//	//	cfg.setAlias(cfg.getTable());
+				//	//}
+				//	String c = ((AbstractSQLConfig<?, ?, ?>) outerConfig2).gainGroupString(false);
+				//
+				//	if (StringUtil.isNotEmpty(c, true)) {
+				//		joinGroup += (first ? "" : ", ") + c;
+				//		first = false;
+				//	}
+				//}
 			}
 		}
 
@@ -1650,7 +1646,7 @@ public abstract class AbstractSQLConfig<T, M extends Map<String, Object>, L exte
 					continue;
 				}
 
-				SQLConfig<T, M, L> ocfg = join.getOuterConfig();
+				SQLConfig<T, M, L> ocfg = join.getOnConfig();
 				SQLConfig<T, M, L> cfg = (ocfg != null && ocfg.getHaving() != null) || join.isLeftOrRightJoin() ? ocfg : join.getJoinConfig();
 
 				if (cfg != null) {
@@ -1763,7 +1759,7 @@ public abstract class AbstractSQLConfig<T, M extends Map<String, Object>, L exte
 					continue;
 				}
 
-				SQLConfig<T, M, L> ocfg = join.getOuterConfig();
+				SQLConfig<T, M, L> ocfg = join.getOnConfig();
 				SQLConfig<T, M, L> cfg = (ocfg != null && ocfg.getSample() != null) || join.isLeftOrRightJoin() ? ocfg : join.getJoinConfig();
 
 				if (cfg != null) {
@@ -1833,7 +1829,7 @@ public abstract class AbstractSQLConfig<T, M extends Map<String, Object>, L exte
 					continue;
 				}
 
-				SQLConfig<T, M, L> ocfg = join.getOuterConfig();
+				SQLConfig<T, M, L> ocfg = join.getOnConfig();
 				SQLConfig<T, M, L> cfg = (ocfg != null && ocfg.getLatest() != null) || join.isLeftOrRightJoin() ? ocfg : join.getJoinConfig();
 
 				if (cfg != null) {
@@ -1898,7 +1894,7 @@ public abstract class AbstractSQLConfig<T, M extends Map<String, Object>, L exte
 					continue;
 				}
 
-				SQLConfig<T, M, L> ocfg = join.getOuterConfig();
+				SQLConfig<T, M, L> ocfg = join.getOnConfig();
 				SQLConfig<T, M, L> cfg = (ocfg != null && ocfg.getPartition() != null) || join.isLeftOrRightJoin() ? ocfg : join.getJoinConfig();
 
 				if (cfg != null) {
@@ -1963,7 +1959,7 @@ public abstract class AbstractSQLConfig<T, M extends Map<String, Object>, L exte
 					continue;
 				}
 
-				SQLConfig<T, M, L> ocfg = join.getOuterConfig();
+				SQLConfig<T, M, L> ocfg = join.getOnConfig();
 				SQLConfig<T, M, L> cfg = (ocfg != null && ocfg.getFill() != null) || join.isLeftOrRightJoin() ? ocfg : join.getJoinConfig();
 
 				if (cfg != null) {
@@ -2029,6 +2025,7 @@ public abstract class AbstractSQLConfig<T, M extends Map<String, Object>, L exte
 	public String gainOrderString(boolean hasPrefix) {
 		//加上子表的 order
 		String joinOrder = "";
+		String joinOuterOrder = "";
 		if (joinList != null) {
 			boolean first = true;
 			for (Join<T, M, L> join : joinList) {
@@ -2036,7 +2033,7 @@ public abstract class AbstractSQLConfig<T, M extends Map<String, Object>, L exte
 					continue;
 				}
 
-				SQLConfig<T, M, L> ocfg = join.getOuterConfig();
+				SQLConfig<T, M, L> ocfg = join.getOnConfig();
 				SQLConfig<T, M, L> cfg = (ocfg != null && ocfg.getOrder() != null) || join.isLeftOrRightJoin() ? ocfg : join.getJoinConfig();
 
 				if (cfg != null) {
@@ -2345,7 +2342,7 @@ public abstract class AbstractSQLConfig<T, M extends Map<String, Object>, L exte
 						continue;
 					}
 
-					SQLConfig<T, M, L> ocfg = join.getOuterConfig();
+					SQLConfig<T, M, L> ocfg = join.getOnConfig();
 					boolean isEmpty = ocfg == null || ocfg.getColumn() == null;
 					boolean isLeftOrRightJoin = join.isLeftOrRightJoin();
 
@@ -3729,8 +3726,9 @@ public abstract class AbstractSQLConfig<T, M extends Map<String, Object>, L exte
 			List<Object> pvl = new ArrayList<>(getPreparedValueList());
 
 			SQLConfig<T, M, L> jc;
+			SQLConfig<T, M, L> outerConfig;
 			String js;
-
+			boolean isWsEmpty = StringUtil.isEmpty(ws, true);
 			boolean changed = false;
 			// 各种 JOIN 没办法统一用 & | ！连接，只能按优先级，和 @combine 一样?
 			for (Join<T, M, L> j : joinList) {
@@ -3741,6 +3739,24 @@ public abstract class AbstractSQLConfig<T, M extends Map<String, Object>, L exte
 				case "@": // APP JOIN
 				case "<": // LEFT JOIN
 				case ">": // RIGHT JOIN
+					outerConfig = j.getOuterConfig();
+					if (outerConfig == null){
+						break;
+					}
+					boolean isMain1 = outerConfig.isMain();
+					outerConfig.setMain(false).setPrepared(isPrepared()).setPreparedValueList(new ArrayList<Object>());
+					String outerWhere = outerConfig.gainWhereString(false);
+
+					int logic1 = Logic.getType(jt);
+					newWs += " ( "
+							+ gainCondition(
+							Logic.isNot(logic1),
+							ws
+									+ ( isWsEmpty ? "" : (Logic.isAnd(logic1) ? AND : OR) )
+									+ " ( " + outerWhere + " ) "
+					)
+							+ " ) ";
+					changed = true;
 					break;
 
 				case "&": // INNER JOIN: A & B
@@ -3761,7 +3777,7 @@ public abstract class AbstractSQLConfig<T, M extends Map<String, Object>, L exte
 					boolean isSideJoin = "^".equals(jt);
 					boolean isAntiJoin = "(".equals(jt);
 					boolean isForeignJoin = ")".equals(jt);
-					boolean isWsEmpty = StringUtil.isEmpty(ws, true);
+					//boolean isWsEmpty = StringUtil.isEmpty(ws, true);
 
 					if (isWsEmpty) {
 						if (isOuterJoin) { // ! OUTER JOIN: ! (A | B)
@@ -5202,7 +5218,7 @@ public abstract class AbstractSQLConfig<T, M extends Map<String, Object>, L exte
 							);
 				}
 
-				SQLConfig<T, M, L> oc = j.getOuterConfig();
+				SQLConfig<T, M, L> oc = j.getOnConfig();
 				String ow = null;
 				if (oc != null) {
 					oc.setPrepared(isPrepared());
@@ -6305,13 +6321,22 @@ public abstract class AbstractSQLConfig<T, M extends Map<String, Object>, L exte
 
 				joinConfig.setMain(false).setKeyPrefix(true);
 
+				if (join.getOn() != null) {
+					SQLConfig<T, M, L> onConfig = newSQLConfig(method, table, alias, join.getOn(), null, false, callback);
+					onConfig.setMain(false)
+							.setKeyPrefix(true)
+							.setDatabase(joinConfig.getDatabase())
+							.setSchema(joinConfig.getSchema()); //解决主表 JOIN 副表，引号不一致
+
+					join.setOnConfig(onConfig);
+				}
+
 				if (join.getOuter() != null) {
 					SQLConfig<T, M, L> outerConfig = newSQLConfig(method, table, alias, join.getOuter(), null, false, callback);
 					outerConfig.setMain(false)
 							.setKeyPrefix(true)
 							.setDatabase(joinConfig.getDatabase())
 							.setSchema(joinConfig.getSchema()); //解决主表 JOIN 副表，引号不一致
-
 					join.setOuterConfig(outerConfig);
 				}
 			}

--- a/APIJSONORM/src/main/java/apijson/orm/Join.java
+++ b/APIJSONORM/src/main/java/apijson/orm/Join.java
@@ -25,12 +25,14 @@ public class Join<T, M extends Map<String, Object>, L extends List<Object>> {
 	private List<On> onList;  // ON User.id = Moment.userId AND ...
 
 	private M request;  // { "id@":"/Moment/userId" }
-	private M outer;  // "join": { "</User": { "@order":"id-", "@group":"id", "name~":"a", "tag$":"%a%", "@combine": "name~,tag$" } } 中的 </User 对应值
+	private M on;  // "join": { "</User": { "@order":"id-", "@group":"id", "name~":"a", "tag$":"%a%", "@combine": "name~,tag$" } } 中的 </User 对应值
 
+	private M outer; // "join": { "</User": { "key2": value2, "@column": "key2,key3","@group": "key2+" }}
 	private SQLConfig<T, M, L> joinConfig;
 	private SQLConfig<T, M, L> cacheConfig;
-	private SQLConfig<T, M, L> outerConfig;
+	private SQLConfig<T, M, L> onConfig;
 
+	private SQLConfig<T, M, L> outerConfig;
 
 	public String getPath() {
 		return path;
@@ -78,11 +80,27 @@ public class Join<T, M extends Map<String, Object>, L extends List<Object>> {
 	public void setRequest(M request) {
 		this.request = request;
 	}
+	public M getOn() {
+		return on;
+	}
+	public void setOn(M on) {
+		this.on = on;
+	}
+
+	public void setOuter(M outer) {
+		this.outer = outer;
+	}
+
 	public M getOuter() {
 		return outer;
 	}
-	public void setOuter(M outer) {
-		this.outer = outer;
+
+	public SQLConfig<T, M, L> getOuterConfig() {
+		return outerConfig;
+	}
+
+	public void setOuterConfig(SQLConfig<T, M, L> outerConfig) {
+		this.outerConfig = outerConfig;
 	}
 
 	public SQLConfig<T, M, L> getJoinConfig() {
@@ -97,11 +115,11 @@ public class Join<T, M extends Map<String, Object>, L extends List<Object>> {
 	public void setCacheConfig(SQLConfig<T, M, L> cacheConfig) {
 		this.cacheConfig = cacheConfig;
 	}
-	public SQLConfig<T, M, L> getOuterConfig() {
-		return outerConfig;
+	public SQLConfig<T, M, L> getOnConfig() {
+		return onConfig;
 	}
-	public void setOuterConfig(SQLConfig<T, M, L> outerConfig) {
-		this.outerConfig = outerConfig;
+	public void setOnConfig(SQLConfig<T, M, L> onConfig) {
+		this.onConfig = onConfig;
 	}
 
 	public boolean isOne2One() {


### PR DESCRIPTION
AbstractSQLConfig gainWhereString 增加适配逻辑.
1.inner join 本身是最外面增加条件，忽略这种情况
2.onConfig       "@group": "key2+"  // JOIN 外层 GROYP BY key2
                 "@having": "count(key3)>0"  // JOIN 外层 HAVING count(key3)>0
                 "@order": "key2+,key3-"  // JOIN 外层 ORDER BY key2 ASC, key3 DESC  本身这些条件就是加到最外层。

    "join": {
      "</Location_info/code@": {
        "id": "88888",
        "@column": "key2,key3",
        "@group": "key2+",
        "@having": "count(key3)>0",
        "@order": "key2+,key3-"
      },
      "id": "88888",只有这个条件加 on 上.   其他        "@group": "key2+","@having": "count(key3)>0", "@order": "key2+,key3-" 都是加到 最外面的where条件上.