### PR TITLE
fix(logging): Replace printStackTrace() with proper logging

### DIFF
--- a/APIJSONORM/src/main/java/apijson/orm/AbstractParser.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractParser.java
@@ -590,7 +590,7 @@ public abstract class AbstractParser<T, M extends Map<String, Object>, L extends
 			onCommit();
 		}
 		catch (Exception e) {
-			e.printStackTrace();
+			Log.e(TAG, "onObjectParse failed", e);
 			error = e;
 
 			onRollback();
@@ -1022,9 +1022,7 @@ public abstract class AbstractParser<T, M extends Map<String, Object>, L extends
 	 */
 	public M newErrorResult(Exception e, boolean isRoot) {
 		if (e != null) {
-		  	//      if (Log.DEBUG) {
-		  	e.printStackTrace();
-		  	//      }
+		  	Log.e(TAG, "newErrorResult", e);
 
 		  	String msg = CommonException.getMsg(e);
 			int code = CommonException.getCode(e);
@@ -1921,7 +1919,7 @@ public abstract class AbstractParser<T, M extends Map<String, Object>, L extends
 				v = getFromObjOrArr(v, k);
 			} catch (Throwable e) {
 				if (IS_PRINT_BIG_LOG) {
-					e.printStackTrace();
+					Log.e(TAG, "getFromObjOrArr failed", e);
 				}
 				v = null;
 			}
@@ -2230,7 +2228,7 @@ public abstract class AbstractParser<T, M extends Map<String, Object>, L extends
 			commit();
 		}
 		catch (SQLException e) {
-			e.printStackTrace();
+			Log.e(TAG, "onCommit failed", e);
 		}
 	}
 	/**回滚事务
@@ -2245,12 +2243,12 @@ public abstract class AbstractParser<T, M extends Map<String, Object>, L extends
 			rollback();
 		}
 		catch (SQLException e1) {
-			e1.printStackTrace();
+			Log.e(TAG, "onRollback failed", e1);
 			try {
 				rollback(null);
 			}
 			catch (SQLException e2) {
-				e2.printStackTrace();
+				Log.e(TAG, "onRollback with null failed", e2);
 			}
 		}
 	}
@@ -2517,7 +2515,7 @@ public abstract class AbstractParser<T, M extends Map<String, Object>, L extends
 					correctRequest.put(key, obj);
 				}
 			} catch (Exception e) {
-				e.printStackTrace();
+				Log.e(TAG, "parseCorrectRequest failed", e);
 				throw new Exception(e); // 包装一层只是为了打印日志？看起来没必要
 			}
 		}

--- a/APIJSONORM/src/main/java/apijson/orm/AbstractSQLExecutor.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractSQLExecutor.java
@@ -676,7 +676,7 @@ public abstract class AbstractSQLExecutor<T, M extends Map<String, Object>, L ex
 					rs.close();
 				}
 				catch (Exception e) {
-					e.printStackTrace();
+					Log.e(TAG, "close ResultSet failed", e);
 				}
 			}
 		}
@@ -947,7 +947,7 @@ public abstract class AbstractSQLExecutor<T, M extends Map<String, Object>, L ex
 							rs.close();
 						}
 						catch (Exception e) {
-							e.printStackTrace();
+							Log.e(TAG, "close ResultSet failed in executeAppJoin", e);
 						}
 					}
 				}
@@ -1125,7 +1125,7 @@ public abstract class AbstractSQLExecutor<T, M extends Map<String, Object>, L ex
 				br.close();
 			}
 			catch (Exception e) {
-				e.printStackTrace();
+				Log.e(TAG, "close BufferedReader failed", e);
 			}
 		}
 
@@ -1194,7 +1194,7 @@ public abstract class AbstractSQLExecutor<T, M extends Map<String, Object>, L ex
 				return true;
 			}
 		} catch (SQLException e) {
-			e.printStackTrace();
+			Log.e(TAG, "isJsonColumn failed", e);
 		}
 		//		List<String> json = config.getJson();
 		//		return json != null && json.contains(label);
@@ -1357,7 +1357,7 @@ public abstract class AbstractSQLExecutor<T, M extends Map<String, Object>, L ex
 					}
 				}
 				catch (SQLException e) {
-					e.printStackTrace();
+					Log.e(TAG, "setAutoCommit failed in rollback", e);
 				}
 			}
 		}
@@ -1384,7 +1384,7 @@ public abstract class AbstractSQLExecutor<T, M extends Map<String, Object>, L ex
 					}
 				}
 				catch (SQLException e) {
-					e.printStackTrace();
+					Log.e(TAG, "rollback failed", e);
 				}
 			}
 		}
@@ -1416,7 +1416,7 @@ public abstract class AbstractSQLExecutor<T, M extends Map<String, Object>, L ex
 					}
 				}
 				catch (SQLException e) {
-					e.printStackTrace();
+					Log.e(TAG, "rollback with savepoint failed", e);
 				}
 			}
 		}
@@ -1442,7 +1442,7 @@ public abstract class AbstractSQLExecutor<T, M extends Map<String, Object>, L ex
 					}
 				}
 				catch (SQLException e) {
-					e.printStackTrace();
+					Log.e(TAG, "commit failed", e);
 				}
 			}
 		}
@@ -1473,7 +1473,7 @@ public abstract class AbstractSQLExecutor<T, M extends Map<String, Object>, L ex
 					}
 				}
 				catch (SQLException e) {
-					e.printStackTrace();
+					Log.e(TAG, "close connection failed", e);
 				}
 			}
 		}

--- a/APIJSONORM/src/main/java/apijson/orm/JSONRequest.java
+++ b/APIJSONORM/src/main/java/apijson/orm/JSONRequest.java
@@ -99,7 +99,7 @@ public class JSONRequest implements apijson.JSONRequest<LinkedHashMap<String, Ob
             target = JSON.parse(value);
         } catch (Exception e) {
             // nothing
-			e.printStackTrace();
+			Log.e(TAG, "JSON.parse failed for key: " + key, e);
         }
         //		if (target == null) { // "tag":"User" 报错
 		//			return null;

--- a/APIJSONORM/src/main/java/apijson/orm/script/JSR223ScriptExecutor.java
+++ b/APIJSONORM/src/main/java/apijson/orm/script/JSR223ScriptExecutor.java
@@ -12,6 +12,7 @@ import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.SimpleBindings;
 
+import apijson.Log;
 import apijson.orm.AbstractFunctionParser;
 
 /**
@@ -45,7 +46,7 @@ public abstract class JSR223ScriptExecutor<T, M extends Map<String, Object>, L e
 			CompiledScript compiledScript = ((Compilable) scriptEngine).compile(convertScript(script));
 			compiledScriptMap.put(name, compiledScript);
 		} catch (Exception e) {
-			e.printStackTrace();
+			Log.e(TAG, "compile script failed: " + name, e);
 		}
 
 	}


### PR DESCRIPTION
## Summary

Replace all `e.printStackTrace()` calls with `Log.e()` to follow best practices for error handling and logging.

## Changes

This PR replaces all instances of `e.printStackTrace()` with proper logging using the project's `Log.e()` method, providing:

- **Consistent logging format** with timestamps
- **Better error tracking** in production environments
- **Controllable logging** via `Log.DEBUG` flag
- **More meaningful error messages** with context

## Files Modified

- `AbstractSQLExecutor.java`: 9 replacements (ResultSet close, transaction errors, connection close)
- `AbstractParser.java`: 6 replacements (parse errors, transaction commit/rollback)
- `JSONRequest.java`: 1 replacement (JSON parse error)
- `JSR223ScriptExecutor.java`: 1 replacement (script compilation error)

## Type

- [x] Bug Fix (improves error handling and debugging)
- [ ] Feature
- [ ] Refactoring
- [ ] Documentation

## Checklist

- [x] Tests pass locally
- [x] Follows project coding style
- [x] Self-review completed
- [x] Commit messages follow guidelines

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>