### PR TITLE
fix: fix global @explain not effective

### DIFF
--- a/APIJSONORM/src/main/java/apijson/orm/AbstractObjectParser.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractObjectParser.java
@@ -375,7 +375,7 @@ public abstract class AbstractObjectParser<T, M extends Map<String, Object>, L e
 
 					if (isSubquery == false) { // 解决 SQL 语法报错，子查询不能 EXPLAIN
 						Boolean exp = parser.getGlobalExplain();
-						if (sch != null) {
+						if (exp != null) {
 							sqlRequest.putIfAbsent(JSONMap.KEY_EXPLAIN, exp);
 						}
 


### PR DESCRIPTION
## Ⅰ. Describe what this PR did
This PR fixes the global @explain propagation logic in AbstractObjectParser.

Previously, root-level @explain was parsed correctly as a global option, but when the framework applied global defaults to table objects, it checked globalSchema instead of globalExplain before injecting KEY_EXPLAIN. As a result, global @explain only worked when global @schema was also present.

This change updates the condition to check the global explain flag itself, so root-level @explain now works as documented without depending on @schema.
## Ⅱ. Does this pull request fix one issue?
fixes [#851](https://github.com/Tencent/APIJSON/issues/851)
## Ⅲ. Why don't you add test cases (unit test/integration test)?
This repository currently does not have an existing test structure under APIJSONORM/src/test, and this PR keeps the change minimal and focused to a one-line bug fix.

The change was verified by compilation and by tracing the request parsing path against the reported issue scenario.
## Ⅳ. Describe how to verify it
Run:
```
mvn -f APIJSONORM/pom.xml -DskipTests compile
```
## Ⅴ. Special notes for reviews
This is a minimal fix that only corrects the propagation condition for global @explain.
It does not change:
subquery behavior
object-level @explain behavior
any SQL generation logic beyond the global default injection path