### PR TITLE
fix: prevent batch insert loss during unique validation

### DIFF
--- a/APIJSONORM/src/main/java/apijson/orm/AbstractVerifier.java
+++ b/APIJSONORM/src/main/java/apijson/orm/AbstractVerifier.java
@@ -1814,7 +1814,8 @@ public abstract class AbstractVerifier<T, M extends Map<String, Object>, L exten
 		config.setTable(table);
 		param.forEach((key,value) -> config.putWhere(key, value, false));
 
-		SQLExecutor<T, M, L> executor = parser.getSQLExecutor();
+		SQLExecutor<T, M, L> executor = parser.createSQLExecutor();
+		executor.setParser(parser);
 		try {
 			M result = executor.execute(config, false);
 			if (result == null) {
@@ -1902,7 +1903,8 @@ public abstract class AbstractVerifier<T, M extends Map<String, Object>, L exten
 		}
 		param.forEach((key,value) -> config.putWhere(key,value, false));
 
-		SQLExecutor<T, M, L> executor = parser.getSQLExecutor();
+		SQLExecutor<T, M, L> executor = parser.createSQLExecutor();
+		executor.setParser(parser);
 		try {
 			M result = executor.execute(config, false);
 			if (result == null) {


### PR DESCRIPTION
## Summary

Fixes #865.

When batch inserting data with unique validation enabled, only the last record was committed successfully.

`verifyExist` and `verifyRepeat` previously reused the parser's shared SQL executor. Their cleanup logic closed that executor and cleared its connection map, causing previously inserted records to be excluded from the final transaction commit.

This change creates an independent SQL executor for verifier checks and binds it to the current parser, keeping verifier lifecycle management isolated from the parser transaction.

## Changes

- Use `parser.createSQLExecutor()` in `verifyExist`
- Use `parser.createSQLExecutor()` in `verifyRepeat`
- Bind the new executor with `executor.setParser(parser)`
- Preserve the parser's shared executor for batch insert transactions

## Verification

- `mvn -q -f APIJSONORM/pom.xml test` passed
- `git diff --check` passed